### PR TITLE
Update links to project's GitHub in the plugin descriptor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The Python code development plugin for [MicroPython](http://micropython.org/) de
 
 The plugin supports Python development for these devices:
 
-* [ESP8266](https://github.com/vlasovskikh/intellij-micropython/wiki/ESP8266)
-* [PyBoard](https://github.com/vlasovskikh/intellij-micropython/wiki/Pyboard)
-* [BBC Micro:bit](https://github.com/vlasovskikh/intellij-micropython/wiki/BBC-Micro%3Abit)
+* [ESP8266](https://github.com/JetBrains/intellij-micropython/wiki/ESP8266)
+* [PyBoard](https://github.com/JetBrains/intellij-micropython/wiki/Pyboard)
+* [BBC Micro:bit](https://github.com/JetBrains/intellij-micropython/wiki/BBC-Micro%3Abit)
 * [Raspberry Pi Pico](https://www.raspberrypi.org/products/raspberry-pi-pico/)
 
 It will support more MicroPython devices and more device-specific and MicroPython-specific modules eventually. We are

--- a/src/main/kotlin/com/jetbrains/micropython/devices/Esp8266DeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/Esp8266DeviceProvider.kt
@@ -20,7 +20,7 @@ class Esp8266DeviceProvider : MicroPythonDeviceProvider {
     get() = "ESP8266"
 
   override val documentationURL: String
-    get() = "https://github.com/vlasovskikh/intellij-micropython/wiki/ESP8266"
+    get() = "https://github.com/JetBrains/intellij-micropython/wiki/ESP8266"
 
   override val usbIds: List<MicroPythonUsbId>
     get() = listOf(

--- a/src/main/kotlin/com/jetbrains/micropython/devices/MicroBitDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/MicroBitDeviceProvider.kt
@@ -36,7 +36,7 @@ open class MicroBitDeviceProvider : MicroPythonDeviceProvider {
     get() = "Micro:bit"
 
   override val documentationURL: String
-    get() = "https://github.com/vlasovskikh/intellij-micropython/wiki/BBC-Micro:bit"
+    get() = "https://github.com/JetBrains/intellij-micropython/wiki/BBC-Micro:bit"
 
   override val usbIds: List<MicroPythonUsbId>
     get() = listOf(MicroPythonUsbId(0x0D28, 0x0204))

--- a/src/main/kotlin/com/jetbrains/micropython/devices/PyboardDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/PyboardDeviceProvider.kt
@@ -36,7 +36,7 @@ class PyboardDeviceProvider : MicroPythonDeviceProvider {
     get() = "Pyboard"
 
   override val documentationURL: String
-    get() = "https://github.com/vlasovskikh/intellij-micropython/wiki/Pyboard"
+    get() = "https://github.com/JetBrains/intellij-micropython/wiki/Pyboard"
 
   override val usbIds: List<MicroPythonUsbId>
     get() = listOf(MicroPythonUsbId(0xF055, 0x9800))

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,8 +1,8 @@
-<idea-plugin url="https://github.com/vlasovskikh/intellij-micropython">
+<idea-plugin url="https://github.com/JetBrains/intellij-micropython">
   <name>MicroPython</name>
   <id>intellij-micropython</id>
   <change-notes><![CDATA[
-      <p>See <a href="https://github.com/vlasovskikh/intellij-micropython/blob/master/CHANGES.md">CHANGES.md</a> on GitHub.</p>
+      <p>See <a href="https://github.com/JetBrains/intellij-micropython/blob/master/CHANGES.md">CHANGES.md</a> on GitHub.</p>
     ]]></change-notes>
   <description><![CDATA[
       <p>Support for MicroPython devices in PyCharm and IntelliJ.</p>
@@ -16,7 +16,7 @@
       </ul>
       <br/>
       <p>Currently the plugin supports ESP8266, Pyboard, Micro:bit, and Raspberry Pi Pico devices. Your feedback and contributions
-        are welcome! See <a href="https://github.com/vlasovskikh/intellij-micropython">the project page</a> on GitHub.</p>
+        are welcome! See <a href="https://github.com/JetBrains/intellij-micropython">the project page</a> on GitHub.</p>
     ]]></description>
   <version>SNAPSHOT</version>
   <vendor>JetBrains</vendor>


### PR DESCRIPTION
At the moment they all point to the old repo (`vlasovskikh`) and that leads to an additional redirect when clicking on links in plugin's description.