### PR TITLE
Auto-detect a wider range of RP2040 devices

### DIFF
--- a/scripts/findusb.py
+++ b/scripts/findusb.py
@@ -15,51 +15,17 @@
 """Find USB devices.
 
 Usage:
-    findusb [VID:PID...]
+    findusb
 
-Arguments:
-    VID:PID       Vendor ID and Product ID for your USB device.
-
-If you run it with no arguments, it outputs the list of all the USB devices it
-has managed to find.
+Outputs the list of all USB devices it has managed to find.
 """
 
-import sys
-from typing import Iterable, Tuple, List
-
-from docopt import docopt
 from serial.tools.list_ports import comports
 
-
-def find_devices(ids: List[Tuple[int, int]]) -> Iterable[str]:
-    for port in comports():
-        if (port.vid, port.pid) in ids:
-            yield port.device
-
-
-def parse_int(s: str) -> int:
-    if s.startswith('0x'):
-        return int(s, 16)
-    else:
-        return int(s)
-
-
-def parse_id(arg: str) -> Tuple[int, int]:
-    vendor_id, product_id = arg.split(':', 1)
-    return parse_int(vendor_id), parse_int(product_id)
-
-
 def main() -> None:
-    opts = docopt(__doc__, argv=sys.argv[1:])
-    vid_pid_list = opts['VID:PID']
-    if vid_pid_list:
-        ids = [parse_id(arg) for arg in sys.argv[1:]]
-        for device in find_devices(ids):
-            print(device)
-    else:
-        for port in comports():
-            if port.vid is not None and port.pid is not None:
-                print('%s: 0x%02x:0x%02x' % (port.device, port.vid, port.pid))
+    for port in comports():
+        if port.vid is not None and port.pid is not None:
+            print('0x%02x:0x%02x %s' % (port.vid, port.pid, port.device))
 
 
 if __name__ == '__main__':

--- a/src/main/kotlin/com/jetbrains/micropython/devices/Esp8266DeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/Esp8266DeviceProvider.kt
@@ -22,7 +22,9 @@ class Esp8266DeviceProvider : MicroPythonDeviceProvider {
   override val documentationURL: String
     get() = "https://github.com/vlasovskikh/intellij-micropython/wiki/ESP8266"
 
-  override val usbIds: List<MicroPythonUsbId>
+  override fun checkUsbId(usbId: MicroPythonUsbId): Boolean = usbIds.contains(usbId)
+
+  val usbIds: List<MicroPythonUsbId>
     get() = listOf(
       MicroPythonUsbId(0x1A86, 0x7523),
       MicroPythonUsbId(0x10C4, 0xEA60),

--- a/src/main/kotlin/com/jetbrains/micropython/devices/MicroBitDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/MicroBitDeviceProvider.kt
@@ -38,8 +38,7 @@ open class MicroBitDeviceProvider : MicroPythonDeviceProvider {
   override val documentationURL: String
     get() = "https://github.com/vlasovskikh/intellij-micropython/wiki/BBC-Micro:bit"
 
-  override val usbIds: List<MicroPythonUsbId>
-    get() = listOf(MicroPythonUsbId(0x0D28, 0x0204))
+  override fun checkUsbId(usbId: MicroPythonUsbId): Boolean = usbId == MicroPythonUsbId(0x0D28, 0x0204)
 
   override fun getPackageRequirements(sdk: Sdk): List<PyRequirement> {
     val manager = PyPackageManager.getInstance(sdk)

--- a/src/main/kotlin/com/jetbrains/micropython/devices/MicroPythonDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/MicroPythonDeviceProvider.kt
@@ -43,9 +43,7 @@ interface MicroPythonDeviceProvider {
   val persistentName: String
 
   val documentationURL: String
-
-  val usbIds: List<MicroPythonUsbId>
-    get() = emptyList()
+  fun checkUsbId(usbId: MicroPythonUsbId): Boolean
 
   val presentableName: String
     get() = persistentName

--- a/src/main/kotlin/com/jetbrains/micropython/devices/PyboardDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/PyboardDeviceProvider.kt
@@ -38,8 +38,7 @@ class PyboardDeviceProvider : MicroPythonDeviceProvider {
   override val documentationURL: String
     get() = "https://github.com/vlasovskikh/intellij-micropython/wiki/Pyboard"
 
-  override val usbIds: List<MicroPythonUsbId>
-    get() = listOf(MicroPythonUsbId(0xF055, 0x9800))
+  override fun checkUsbId(usbId: MicroPythonUsbId): Boolean = usbId == MicroPythonUsbId(0xF055, 0x9800)
 
   override val typeHints: MicroPythonTypeHints by lazy {
     MicroPythonTypeHints(listOf("stdlib", "micropython", "pyboard"))

--- a/src/main/kotlin/com/jetbrains/micropython/devices/RPiPicoDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/RPiPicoDeviceProvider.kt
@@ -22,8 +22,31 @@ class RPiPicoDeviceProvider : MicroPythonDeviceProvider {
   override val documentationURL: String
     get() = "https://www.raspberrypi.com/documentation/microcontrollers/raspberry-pi-pico.html"
 
-  override val usbIds: List<MicroPythonUsbId>
-    get() = listOf(MicroPythonUsbId(0x2E8A, 0x05))
+  /**
+   * From https://github.com/raspberrypi/usb-pid :
+   *
+   * "The USB-IF have given Raspberry Pi permission to sub-license the USB product ID values for its vendor ID (0x2E8A)
+   * since they are to be used on a common silicon component which will be used within a customer's product (the RP2040
+   * silicon)."
+   *
+   * Consequently, most usb devices with the vendor id 0x2E8A are likely to be an RP2040, and therefore capable of
+   * running MicroPython.
+   */
+  override fun checkUsbId(usbId: MicroPythonUsbId): Boolean =
+          usbId.vendorId == 0x2E8A && ProductId.likelyToRunMicroPython(usbId.productId)
+
+  object ProductId {
+    private const val PICO_WITH_STANDARD_MICROPYTHON_FIRMWARE = 0x05
+
+    /**
+     * Raspberry Pi have allocated the productId range 0x1000 - 0x1fff for Commercial RP2040 devices.
+     * See https://github.com/raspberrypi/usb-pid#assignment
+     */
+    private val COMMERCIAL_RANGE = 0x1000..0x1fff
+
+    fun likelyToRunMicroPython(productId: Int): Boolean =
+            productId == PICO_WITH_STANDARD_MICROPYTHON_FIRMWARE || productId in COMMERCIAL_RANGE
+  }
 
   override val typeHints: MicroPythonTypeHints by lazy {
     MicroPythonTypeHints(listOf("stdlib", "micropython", "rpi_pico"))

--- a/src/main/kotlin/com/jetbrains/micropython/settings/MicroPythonUsbId.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/settings/MicroPythonUsbId.kt
@@ -3,4 +3,11 @@ package com.jetbrains.micropython.settings
 /**
  * @author vlan
  */
-data class MicroPythonUsbId(val vendorId: Int, val productId: Int)
+data class MicroPythonUsbId(val vendorId: Int, val productId: Int) {
+    companion object {
+        fun parse(vendorAndProductId: String): MicroPythonUsbId {
+            val ints = vendorAndProductId.split(':').map { Integer.decode(it) }
+            return MicroPythonUsbId(ints[0], ints[1])
+        }
+    }
+}


### PR DESCRIPTION
At the moment, the device-path detection for Raspberry Pi USB devices only recognises one specific id: `2E8A:0005`, the vanilla [Raspberry Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico/) running MicroPython firmware: 

<img width="990" alt="image" src="https://github.com/JetBrains/intellij-micropython/assets/52038/d7ee593a-2a60-4f08-8884-f94b599e8d52">


### Plethora of RP2040 devices...

However, there are many devices using the [RP2040](https://www.raspberrypi.com/documentation/microcontrollers/rp2040.html) that are similar to the Raspberry Pi Pico and [run MicroPython](https://micropython.org/download/?port=rp2) in the same way (_[Adafruit Feather RP2040](https://micropython.org/download/ADAFRUIT_FEATHER_RP2040/), [Pimoroni Badger 2040](https://shop.pimoroni.com/products/badger-2040), [Raspberry Breadstick](https://www.crowdsupply.com/breadstick-innovations/raspberry-breadstick)_, etc) -  these all use the same vendor id as the Pico (`2E8A`), but have different product ids from the large `0x1000` - `0x1fff` range which [Raspberry Pi sub-license](https://github.com/raspberrypi/usb-pid#allocation).

Not _all_ of the devices in the `0x1000` - `0x1fff` range actually run MicroPython (eg `0x1069`, the [Zoid Technology Matrix](https://zoid.com.au/matrix/), runs QMK firmware and quite possibly doesn't have a MicroPython build), but if it's plugged into a developers machine and they're trying to access MicroPython on it, it _probably_ does.


## Changes made in this PR

* The `findusb.py` Python script  is now much shorter, and no longer takes target usb ids as an argument - it just outputs the full list of attached usb devices (the list is unlikely to be very long - say, fewer than 100 devices) and allows the Kotlin code to do the filtering
* In `MicroPythonDeviceProvider`, the fixed list of `usbIds` is replaced with replaced with a `checkUsbId()` method - this is used to filter the list of usb ids returned by `findusb.py`. This lets us accept much wider ranges of usb ids without having to define 100s of 'known' `MicroPythonUsbId`s.

See https://github.com/raspberrypi/usb-pid#assignment - Raspberry Pi have allocated the productId range **0x1000 - 0x1fff** for Commercial RP2040 devices, of which they have allocated over 100 ids as of 2023.