### PR TITLE
Don't bundle kotlin stdlib into plugin archive

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,8 @@ version=SNAPSHOT
 ideaVersion=PC-232-EAP-SNAPSHOT
 pythonPlugin=PythonCore:232.9921.47
 publishToken=token
+
+# Since kotlin 1.4, stdlib dependency is added by default by kotlin gradle plugin.
+# But we don't need it because all necessary kotlin libraries are already bundled into IDE.
+# See https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library for more details
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
IntelliJ IDEs already contain all Kotlin stdlib which is supposed to be used by the plugin in runtime. Bundling an own version of Kotlin stdlib may lead to different class loading issues. Also, it makes the plugin much bigger: about 2 MB before and less than 400 KB now