### PR TITLE
Provide shared run configuration to run IDE with plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .idea/
+!/.idea/runConfigurations/
 .gradle/
 build/
 venv/

--- a/.idea/runConfigurations/runIde.xml
+++ b/.idea/runConfigurations/runIde.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="runIde" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ The steps for setting up the development environment:
 1. Check out this project from GitHub
 2. Create a new project from existing sources in IntelliJ
 
-To just run the development version use `./gradlew clean runIde` from the command line.
+To just run the development version use `./gradlew clean runIde` from the command line
+or just run **runIde** [run configuration](https://www.jetbrains.com/help/idea/run-debug-configuration.html).
 
 Contributions are welcome!
 


### PR DESCRIPTION
It should simplify development workflow (especially for new contributors) because it not only provides an easy way to run IDE with plugin from sources without reading anything but also opens IDE logs in `Run` tool window by default