### PR TITLE
Provide display name for `MicroPython` configurable in plugin manifest

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,7 @@
     <runConfigurationProducer implementation="com.jetbrains.micropython.run.MicroPythonRunConfigurationProducer"/>
     <projectConfigurable groupId="language"
                          id="com.jetbrains.micropython.configurable"
+                         displayName="MicroPython"
                          provider="com.jetbrains.micropython.settings.MicroPythonConfigurableProvider"/>
     <projectService serviceImplementation="com.jetbrains.micropython.settings.MicroPythonDevicesConfiguration"/>
     <moduleService serviceImplementation="com.jetbrains.micropython.repl.MicroPythonReplManager"/>


### PR DESCRIPTION
The platform really wants to extract configurable names from plugin manifest without loading configurable extensions themselves to speed up some computations. And if your configurable doesn't provide display name in this way, the platform prints the corresponding error message in log like

```
com.intellij.diagnostic.PluginException: No display name specified in plugin descriptor XML file for configurable com.jetbrains.micropython.settings.MicroPythonProjectConfigurable;
specify it using 'displayName' or 'key' attribute to avoid necessity to load the configurable class when Settings dialog is opened [Plugin: intellij-micropython]
	at com.intellij.openapi.options.ex.ConfigurableWrapper.getDisplayName(ConfigurableWrapper.java:156)
	at com.intellij.openapi.options.ex.Weighted.lambda$static$0(Weighted.java:26)
	at java.base/java.util.TimSort.binarySort(TimSort.java:296)
	at java.base/java.util.TimSort.sort(TimSort.java:221)
	at java.base/java.util.Arrays.sort(Arrays.java:1307)
	at java.base/java.util.ArrayList.sort(ArrayList.java:1721)
	at com.intellij.openapi.options.ex.SortedConfigurableGroup.buildConfigurables(SortedConfigurableGroup.java:41)
	at com.intellij.openapi.options.SearchableConfigurable$Parent$Abstract.getConfigurables(SearchableConfigurable.java:75)
	at com.intellij.openapi.options.ex.EpBasedConfigurableGroupKt.collect(EpBasedConfigurableGroup.kt:148)
	at com.intellij.openapi.options.ex.EpBasedConfigurableGroupKt.access$collect(EpBasedConfigurableGroup.kt:1)
	at com.intellij.openapi.options.ex.EpBasedConfigurableGroup.<init>(EpBasedConfigurableGroup.kt:110)
	at com.intellij.openapi.options.ex.ConfigurableExtensionPointUtil.getConfigurableGroup(ConfigurableExtensionPointUtil.java:119)
	at com.intellij.ide.actions.ShowSettingsUtilImpl$Companion.getConfigurableGroups(ShowSettingsUtilImpl.kt:48)
	at com.intellij.ide.actions.ShowSettingsUtilImpl.getConfigurableGroups(ShowSettingsUtilImpl.kt)
	at com.intellij.ide.actions.ShowSettingsAction.perform(ShowSettingsAction.java:60)
```