### PR TITLE
Add simple github actions workflow to check plugin

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,40 @@
+name: check
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    -   cron: '0 3 * * *'
+
+# Allow cancelling all previous runs for the same branch
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-plugin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+
+      - name: Build plugin
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ":buildPlugin -Pversion=SNAPSHOT-${{ github.run_number }}"
+
+      - name: Upload plugin archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: intellij-micropython-SNAPSHOT-${{ github.run_number }}
+          path: build/distributions/intellij-micropython-SNAPSHOT-${{ github.run_number }}.zip


### PR DESCRIPTION
Currently, it only checks that it's possible to compile plugin code