### PR TITLE
typehints/esp32: Fix several syntax errors in the type stubs.

### DIFF
--- a/typehints/esp32/esp.pyi
+++ b/typehints/esp32/esp.pyi
@@ -10,15 +10,20 @@ LOG_VERBOSE: Final[int] = ...
 
 def flash_size():
     """Read the total size of the flash memory."""
+    ...
 
 def flash_user_start():
     """Read the memory offset at which the user flash space begins."""
+    ...
 
 def flash_read(byte_offset, length_or_buffer):
+    ...
 
 def flash_write(byte_offset, bytes):
+    ...
 
 def flash_erase(sector_no):
+    ...
 
 def osdebug(level: Optional[int]):
     """
@@ -33,3 +38,4 @@ def osdebug(level: Optional[int]):
     * ``LOG_DEBUG`` – Extra information which is not necessary for normal use (values, pointers, sizes, etc)
     * ``LOG_VERBOSE`` – Bigger chunks of debugging information, or frequent messages which can potentially flood the output
     """
+    ...

--- a/typehints/esp32/esp32.pyi
+++ b/typehints/esp32/esp32.pyi
@@ -1,5 +1,5 @@
 from machine import Pin
-from typing import Optional
+from typing import Optional, overload
 from typing import Final
 
 HEAP_DATA: Final[int] = ...
@@ -105,7 +105,7 @@ class Partition:
         """
 
     @classmethod
-    def find(self, type=TYPE_APP, subtype=0xff, label=None, block_size=4096) -> list:
+    def find(self, type=TYPE_APP, subtype=0xFF, label=None, block_size=4096) -> list:
         """
         Find a partition specified by type, subtype and label.
 
@@ -120,14 +120,14 @@ class Partition:
         :return: A 6-tuple ``(type, subtype, addr, size, label, encrypted)``.
         """
 
-    def readblocks(self, block_num, buf):
-
-    def readblocks(self, block_num, buf, offset):
-
-    def writeblocks(self, block_num, buf):
-
-    def writeblocks(self, block_num, buf, offset):
-
+    @overload
+    def readblocks(self, block_num, buf): ...
+    @overload
+    def readblocks(self, block_num, buf, offset): ...
+    @overload
+    def writeblocks(self, block_num, buf): ...
+    @overload
+    def writeblocks(self, block_num, buf, offset): ...
     def ioctl(self, cmd, arg):
         """These methods implement the simple and extended block protocol defined by ``os.AbstractBlockDev``."""
 
@@ -227,7 +227,7 @@ class RMT:
         """
 
     @staticmethod
-    def bitstream_channel([value]) -> int:
+    def bitstream_channel(value:int|None) -> int:
         """
         Select which RMT channel is used by the ``machine.bitstream`` implementation.
 


### PR DESCRIPTION
While looking at some of the manual type annotations to assess the possible option of re-using these, 
i noticed a few malformed func defs  that threw errors in pyright and mypy.

I took the liberty of correcting these. 