### PR TITLE
Fixed the bug where the plugin disconnects from the board upon upload cancellation

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/nova/FileSystemWidget.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/FileSystemWidget.kt
@@ -229,8 +229,21 @@ class FileSystemWidget(val project: Project, newDisposable: Disposable) :
                     }
                 }
                 .toCollection(commands)
-            blindExecute(LONG_TIMEOUT, *commands.toTypedArray())
-                .extractResponse()
+            try {
+                blindExecute(LONG_TIMEOUT, *commands.toTypedArray())
+                    .extractResponse()
+            } catch (e: IOException) {
+                if (e.message?.contains("ENOENT") != true) {
+                    throw e
+                }
+            } catch (e: CancellationException) {
+                withContext(NonCancellable) {
+                    withContext(Dispatchers.EDT) {
+                        refresh()
+                    }
+                }
+                throw e
+            }
         }
     }
 

--- a/src/main/kotlin/com/jetbrains/micropython/nova/FileSystemWidget.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/FileSystemWidget.kt
@@ -238,9 +238,7 @@ class FileSystemWidget(val project: Project, newDisposable: Disposable) :
                 }
             } catch (e: CancellationException) {
                 withContext(NonCancellable) {
-                    withContext(Dispatchers.EDT) {
-                        refresh()
-                    }
+                    refresh()
                 }
                 throw e
             }
@@ -261,9 +259,7 @@ class FileSystemWidget(val project: Project, newDisposable: Disposable) :
             comm.upload(relativeName, contentsToByteArray)
         } catch (e: CancellationException) {
             withContext(NonCancellable) {
-                withContext(Dispatchers.EDT) {
-                    refresh()
-                }
+                refresh()
             }
             throw e
         }

--- a/src/main/kotlin/com/jetbrains/micropython/nova/MpyComm.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/MpyComm.kt
@@ -218,7 +218,10 @@ except OSError as e:
                     }
                 }
                 return result
-            } catch (e: Throwable) {
+        } catch (e: CancellationException) {
+            throw e
+        }
+        catch (e: Throwable) {
                 state = State.DISCONNECTED
                 client?.close()
                 client = null


### PR DESCRIPTION
Previously all the exceptions related to board data exchange ended up falling into the (e: Throwable) error catching, which always disconnected from the device. Adding a simple CancellationException error catch fixes the bug. Now the device remains connected even after an upload is cancelled, it will just throw an "Upload cancelled" error and remain connected.