### PR TITLE
Added a check, to only display "execute file" action when applicable

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
@@ -263,18 +263,38 @@ class OpenMpyFile : ReplAction("Open file", true) {
     }
 }
 
-open class UploadFile() : DumbAwareAction("Upload File(s) to Micropython device") {
+open class UploadFile() : DumbAwareAction("Upload File(s) to MicroPython Device") {
     override fun getActionUpdateThread(): ActionUpdateThread = BGT
 
     override fun update(e: AnActionEvent) {
         val project = e.project
-        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
-        if (project != null
-            && file?.isInLocalFileSystem == true
-            && ModuleUtil.findModuleForFile(file, project)?.microPythonFacet != null
-        ) {
-            e.presentation.text =
-                if (file.isDirectory) "Upload Directory to Micropython device" else "Upload File to Micropython device"
+        val files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)
+        if (project != null && files != null) {
+            var directoryCount = 0
+            var normalFileCount = 0
+
+            for (file in files.iterator()) {
+                if (file == null || !file.isInLocalFileSystem || ModuleUtil.findModuleForFile(file, project)?.microPythonFacet == null)
+                    return
+
+                if (file.isDirectory)
+                    directoryCount++
+                else
+                    normalFileCount++
+            }
+
+            if (normalFileCount == 1)
+                e.presentation.text = "Upload File to MicroPython Device"
+            else if (normalFileCount > 1)
+                e.presentation.text = "Upload Files to MicroPython Device"
+            else if (directoryCount == 1)
+                e.presentation.text = "Upload Directory to MicroPython Device"
+            else if (directoryCount > 1)
+                e.presentation.text = "Upload Directories to MicroPython Device"
+            else {
+                e.presentation.text = "Upload File(s) to MicroPython Device"
+                e.presentation.isEnabled = false
+            }
         } else {
             e.presentation.isEnabledAndVisible = false
         }

--- a/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
@@ -170,8 +170,12 @@ class InstantRun : DumbAwareAction() {
     override fun getActionUpdateThread(): ActionUpdateThread = BGT
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabled = e.getData(CommonDataKeys.VIRTUAL_FILE) != null
-
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        val files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)
+        e.presentation.isEnabled = file != null &&
+                !file.isDirectory &&
+                file.extension == "py" &&
+                files?.size == 1
     }
 
     override fun actionPerformed(e: AnActionEvent) {
@@ -277,7 +281,7 @@ open class UploadFile() : DumbAwareAction("Upload File(s) to Micropython device"
     }
 
     override fun actionPerformed(e: AnActionEvent) {
-            FileDocumentManager.getInstance().saveAllDocuments()
+        FileDocumentManager.getInstance().saveAllDocuments()
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
         if (file != null) {
             MicroPythonRunConfiguration.uploadFileOrFolder(e.project ?: return, file)


### PR DESCRIPTION
I've noticed that the "Execute file in REPL" functionality doesn't have a check for whether or not the file can be executed. You could run the action when a folder was selected, when non `.py` files were selected, or on selections of multiple files. 

I've added a check to ensure that the action is only enabled if a single `.py` file is selected.

If it is not, the action will be greyed out.

Only thing that I wasn't entirely sure about is whether to modify the action further, to not show the option at all under certain circumstances, though the way the check works in this commit seems sufficient to me. 