### PR TITLE
Improved upload algorithm, CRC checks, bug fixes, file system view sorting

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/nova/FileSystemWidget.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/FileSystemWidget.kt
@@ -71,20 +71,29 @@ except Exception:
 
 private val MPY_CALCULATE_CRC = { filePath: String ->
     """
+        
 import binascii
 
 try:
+    try:
+        import gc
+        gc.collect()
+    except Exception:
+        pass
+
     with open('$filePath', 'rb') as f:
         crc = '%08x' % (binascii.crc32(f.read()) & 0xffffffff)
-        print(crc)  # Print directly inside the function
+        print(crc)
+        
+    try:
+        import gc
+        gc.collect()
+    except Exception:
+        pass
+        
 except Exception as e:
     print(f"ERROR: {str(e)}")
     
-try:
-    import gc
-    gc.collect()
-except Exception:
-    pass
 """
 }
 
@@ -283,7 +292,6 @@ class FileSystemWidget(val project: Project, newDisposable: Disposable) :
     }
 
     suspend fun deleteCurrent() {
-
         comm.checkConnected()
         val confirmedFileSystemNodes = withContext(Dispatchers.EDT) {
             val fileSystemNodes = tree.selectionPaths?.mapNotNull { it.lastPathComponent.asSafely<FileSystemNode>() }

--- a/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
@@ -170,15 +170,19 @@ class InstantRun : DumbAwareAction() {
     override fun getActionUpdateThread(): ActionUpdateThread = BGT
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabled = e.getData(CommonDataKeys.VIRTUAL_FILE) != null
-
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        val files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)
+        e.presentation.isEnabled = file != null &&
+                !file.isDirectory &&
+                file.extension == "py" &&
+                files?.size == 1
     }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         FileDocumentManager.getInstance().saveAllDocuments()
         val code = e.getData(CommonDataKeys.VIRTUAL_FILE)?.readText() ?: return
-        performReplAction(project,true,"Run code") {
+        performReplAction(project, true, "Run code") {
             it.instantRun(code, false)
         }
     }
@@ -259,28 +263,55 @@ class OpenMpyFile : ReplAction("Open file", true) {
     }
 }
 
-open class UploadFile() : DumbAwareAction("Upload File(s) to MicroPython Device") {
+open class UploadFile() : DumbAwareAction("Upload Item(s) to MicroPython Device") {
     override fun getActionUpdateThread(): ActionUpdateThread = BGT
 
     override fun update(e: AnActionEvent) {
         val project = e.project
-        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
-        if (project != null
-            && file?.isInLocalFileSystem == true
-            && ModuleUtil.findModuleForFile(file, project)?.microPythonFacet != null
-        ) {
-            e.presentation.text =
-                if (file.isDirectory) "Upload Directory to MicroPython Device" else "Upload File to MicroPython Device"
+        val files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)
+        if (project != null && files != null) {
+            var directoryCount = 0
+            var normalFileCount = 0
+
+            for (file in files.iterator()) {
+                if (file == null || !file.isInLocalFileSystem || ModuleUtil.findModuleForFile(
+                        file,
+                        project
+                    )?.microPythonFacet == null
+                ) {
+                    return
+                }
+
+                if (file.isDirectory) {
+                    directoryCount++
+                } else {
+                    normalFileCount++
+                }
+            }
+
+            if (normalFileCount >= 1 && directoryCount >= 1) {
+                e.presentation.text = "Upload Items to MicroPython Device"
+            } else if (normalFileCount == 1) {
+                e.presentation.text = "Upload File to MicroPython Device"
+            } else if (normalFileCount > 1) {
+                e.presentation.text = "Upload Files to MicroPython Device"
+            } else if (directoryCount == 1) {
+                e.presentation.text = "Upload Directory to MicroPython Device"
+            } else if (directoryCount > 1) {
+                e.presentation.text = "Upload Directories to MicroPython Device"
+            } else {
+                e.presentation.text = "Upload Item(s) to MicroPython Device"
+            }
         } else {
             e.presentation.isEnabledAndVisible = false
         }
     }
 
     override fun actionPerformed(e: AnActionEvent) {
-            FileDocumentManager.getInstance().saveAllDocuments()
-        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
-        if (file != null) {
-            MicroPythonRunConfiguration.uploadFileOrFolder(e.project ?: return, file)
+        FileDocumentManager.getInstance().saveAllDocuments()
+        val files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)
+        if (files != null) {
+            MicroPythonRunConfiguration.uploadItems(e.project ?: return, files.toSet())
         }
     }
 }
@@ -292,9 +323,9 @@ class OpenSettingsAction : DumbAwareAction("Settings") {
     }
 }
 
-class InterruptAction: ReplAction("Interrupt", true) {
+class InterruptAction : ReplAction("Interrupt", true) {
     override fun getActionUpdateThread(): ActionUpdateThread = BGT
-    override fun update(e: AnActionEvent)  = enableIfConnected(e)
+    override fun update(e: AnActionEvent) = enableIfConnected(e)
     override val actionDescription: @NlsContexts.DialogMessage String = "Interrupt..."
 
     override suspend fun performAction(fileSystemWidget: FileSystemWidget) {
@@ -302,9 +333,9 @@ class InterruptAction: ReplAction("Interrupt", true) {
     }
 }
 
-class SoftResetAction: ReplAction("Reset", true) {
+class SoftResetAction : ReplAction("Reset", true) {
     override fun getActionUpdateThread(): ActionUpdateThread = BGT
-    override fun update(e: AnActionEvent)  = enableIfConnected(e)
+    override fun update(e: AnActionEvent) = enableIfConnected(e)
     override val actionDescription: @NlsContexts.DialogMessage String = "Reset..."
 
     override suspend fun performAction(fileSystemWidget: FileSystemWidget) {
@@ -326,7 +357,7 @@ class CreateDeviceFolderAction : ReplAction("New Folder", true) {
         }
     }
 
-    override val actionDescription: @NlsContexts.DialogMessage String = "Creating new folder..."
+    override val actionDescription: @NlsContexts.DialogMessage String = "Creating New Folder..."
 
     override suspend fun performAction(fileSystemWidget: FileSystemWidget) {
 

--- a/src/main/kotlin/com/jetbrains/micropython/run/MicroPythonRunConfiguration.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/run/MicroPythonRunConfiguration.kt
@@ -54,233 +54,244 @@ import org.jdom.Element
  * @author Mikhail Golubev, Lukas Kremla
  */
 class MicroPythonRunConfiguration(project: Project, factory: ConfigurationFactory) : AbstractRunConfiguration(project, factory), RunConfigurationWithSuppressedDefaultDebugAction {
-  var path: String = ""
-  var runReplOnSuccess: Boolean = false
-  var resetOnSuccess: Boolean = true
+    var path: String = ""
+    var runReplOnSuccess: Boolean = false
+    var resetOnSuccess: Boolean = true
 
-  override fun getValidModules() =
-    allModules.filter { it.microPythonFacet != null }.toMutableList()
+    override fun getValidModules() =
+        allModules.filter { it.microPythonFacet != null }.toMutableList()
 
-  override fun getConfigurationEditor() = MicroPythonRunConfigurationEditor(this)
+    override fun getConfigurationEditor() = MicroPythonRunConfigurationEditor(this)
 
-  override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? {
-    val success: Boolean
-    val projectDir = project.guessProjectDir()
-    val projectPath = projectDir?.path
-
-    if (path.isBlank() || (projectPath != null && path == projectPath)) {
-      success = uploadProject(project)
-    } else {
-      val toUpload = StandardFileSystems.local().findFileByPath(path) ?: return null
-      success = uploadFileOrFolder(project, toUpload)
-    }
-    if (success) {
-      val fileSystemWidget = fileSystemWidget(project)
-      if (resetOnSuccess) fileSystemWidget?.reset()
-      if (runReplOnSuccess) fileSystemWidget?.activateRepl()
-      return EmptyRunProfileState.INSTANCE
-    } else {
-      return null
-    }
-  }
-
-  override fun checkConfiguration() {
-    super.checkConfiguration()
-    val m = module ?: throw RuntimeConfigurationError("Module for path was not found")
-    val showSettings = Runnable {
-      when {
-        PlatformUtils.isPyCharm() ->
-          ShowSettingsUtil.getInstance().showSettingsDialog(project, MicroPythonProjectConfigurable::class.java)
-
-        PlatformUtils.isIntelliJ() ->
-          ProjectSettingsService.getInstance(project).openModuleSettings(module)
-
-        else ->
-          ShowSettingsUtil.getInstance().showSettingsDialog(project)
-      }
-    }
-    val facet = m.microPythonFacet ?: throw RuntimeConfigurationError(
-      "MicroPython support was not enabled for selected module in IDE settings",
-      showSettings
-    )
-    val validationResult = facet.checkValid()
-    if (validationResult != ValidationResult.OK) {
-      val runQuickFix = Runnable {
-        validationResult.quickFix.run(null)
-      }
-      throw RuntimeConfigurationError(validationResult.errorMessage, runQuickFix)
-    }
-    facet.pythonPath ?: throw RuntimeConfigurationError("Python interpreter is not found")
-  }
-
-  override fun suggestedName() = "Flash ${PathUtil.getFileName(path)}"
-
-  override fun writeExternal(element: Element) {
-    super.writeExternal(element)
-    element.setAttribute("path", path)
-    element.setAttribute("run-repl-on-success", if (runReplOnSuccess) "yes" else "no")
-    element.setAttribute("reset-on-success", if (resetOnSuccess) "yes" else "no")
-  }
-
-  override fun readExternal(element: Element) {
-    super.readExternal(element)
-    configurationModule.readExternal(element)
-    element.getAttributeValue("path")?.let {
-      path = it
-    }
-    element.getAttributeValue("run-repl-on-success")?.let {
-      runReplOnSuccess = it == "yes"
-    }
-    element.getAttributeValue("reset-on-success")?.let {
-      resetOnSuccess = it == "yes"
-    }
-  }
-
-  val module: Module?
-    get() {
-      if (path.isEmpty()) {
+    override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? {
+        val success: Boolean
         val projectDir = project.guessProjectDir()
-        if (projectDir != null) return ModuleUtil.findModuleForFile(projectDir, project)
-      }
-      val file = StandardFileSystems.local().findFileByPath(path) ?: return null
-      return ModuleUtil.findModuleForFile(file, project)
-    }
+        val projectPath = projectDir?.path
 
-  companion object {
-    private fun VirtualFile.leadingDot() = this.name.startsWith(".")
-
-    private fun collectProjectUploadables(project: Project): Set<VirtualFile> {
-      return project.modules.flatMap { module ->
-        val moduleRoots = module.rootManager
-          .contentEntries
-          .flatMap { it.sourceFolders.asSequence() }
-          .mapNotNull { if (!it.isTestSource) it.file else null }
-          .filter { !it.leadingDot() }
-          .toMutableList()
-
-        if (moduleRoots.isEmpty()) {
-          module.rootManager.contentRoots.filterTo(moduleRoots) { it.isDirectory && !it.leadingDot() }
+        if (path.isBlank() || (projectPath != null && path == projectPath)) {
+            success = uploadProject(project)
+        } else {
+            val toUpload = StandardFileSystems.local().findFileByPath(path) ?: return null
+            success = uploadFileOrFolder(project, toUpload)
         }
-        moduleRoots
-      }.toSet()
-    }
-
-    private fun collectExcluded(project: Project): Set<VirtualFile> {
-      val ideaDir = project.stateStore.directoryStorePath?.let { VfsUtil.findFile(it, false) }
-      val excludes = if (ideaDir == null) mutableSetOf<VirtualFile>() else mutableSetOf(ideaDir)
-      project.modules.forEach { module ->
-        PythonSdkUtil.findPythonSdk(module)?.homeDirectory?.apply { excludes.add(this) }
-        module.rootManager.contentEntries.forEach { entry ->
-          excludes.addAll(entry.excludeFolderFiles)
+        if (success) {
+            val fileSystemWidget = fileSystemWidget(project)
+            if (resetOnSuccess) fileSystemWidget?.reset()
+            if (runReplOnSuccess) fileSystemWidget?.activateRepl()
+            return EmptyRunProfileState.INSTANCE
+        } else {
+            return null
         }
-      }
-      return excludes
     }
 
-    private fun collectSourceRoots(project: Project): Set<VirtualFile> {
-      return project.modules.flatMap { module ->
-        module.rootManager.contentEntries
-          .flatMap { entry -> entry.sourceFolders.toList() }
-          .filter { sourceFolder ->
-            !sourceFolder.isTestSource && sourceFolder.file?.let { !it.leadingDot() } ?: false
-          }
-          .mapNotNull { it.file }
-      }.toSet()
-    }
+    override fun checkConfiguration() {
+        super.checkConfiguration()
+        val m = module ?: throw RuntimeConfigurationError("Module for path was not found")
+        val showSettings = Runnable {
+            when {
+                PlatformUtils.isPyCharm() ->
+                    ShowSettingsUtil.getInstance().showSettingsDialog(project, MicroPythonProjectConfigurable::class.java)
 
-    private fun collectTestRoots(project: Project): Set<VirtualFile> {
-      return project.modules.flatMap { module ->
-        module.rootManager.contentEntries
-          .flatMap { entry -> entry.sourceFolders.toList() }
-          .filter { sourceFolder -> sourceFolder.isTestSource }
-          .mapNotNull { it.file }
-      }.toSet()
-    }
+                PlatformUtils.isIntelliJ() ->
+                    ProjectSettingsService.getInstance(project).openModuleSettings(module)
 
-    fun uploadProject(project: Project): Boolean {
-      FileDocumentManager.getInstance().saveAllDocuments()
-      val filesToUpload = collectProjectUploadables(project)
-      return performUpload(project, filesToUpload, true)
-    }
-
-    fun uploadFileOrFolder(project: Project, toUpload: VirtualFile): Boolean {
-      FileDocumentManager.getInstance().saveAllDocuments()
-      return performUpload(project, setOf(toUpload), false)
-    }
-
-    fun uploadItems(project: Project, toUpload: Set<VirtualFile>): Boolean {
-      FileDocumentManager.getInstance().saveAllDocuments()
-      return performUpload(project, toUpload, false)
-    }
-
-    private fun performUpload(project: Project, toUpload: Set<VirtualFile>, isProjectUpload: Boolean): Boolean {
-      val filesToUpload = toUpload.toMutableList()
-      val excludedFolders = collectExcluded(project)
-      val sourceFolders = collectSourceRoots(project)
-      val testFolders = collectTestRoots(project)
-
-      performReplAction(project, true, "Upload files") { fileSystemWidget ->
-        var i = 0
-        while (i < filesToUpload.size) {
-          val file = filesToUpload[i]
-
-          val shouldSkip = !file.isValid ||
-                  file.leadingDot() ||
-                  FileTypeRegistry.getInstance().isFileIgnored(file) ||
-                  excludedFolders.any { VfsUtil.isAncestor(it, file, true) } ||
-                  (isProjectUpload && testFolders.any { VfsUtil.isAncestor(it, file, true) }) ||
-                  (isProjectUpload && sourceFolders.isNotEmpty() &&
-                          !sourceFolders.any { VfsUtil.isAncestor(it, file, false) })
-
-          when {
-            shouldSkip -> {
-              filesToUpload.removeAt(i)
+                else ->
+                    ShowSettingsUtil.getInstance().showSettingsDialog(project)
             }
-
-            file.isDirectory -> {
-              filesToUpload.addAll(file.children)
-              filesToUpload.removeAt(i)
+        }
+        val facet = m.microPythonFacet ?: throw RuntimeConfigurationError(
+            "MicroPython support was not enabled for selected module in IDE settings",
+            showSettings
+        )
+        val validationResult = facet.checkValid()
+        if (validationResult != ValidationResult.OK) {
+            val runQuickFix = Runnable {
+                validationResult.quickFix.run(null)
             }
+            throw RuntimeConfigurationError(validationResult.errorMessage, runQuickFix)
+        }
+        facet.pythonPath ?: throw RuntimeConfigurationError("Python interpreter is not found")
+    }
 
-            else -> i++
-          }
+    override fun suggestedName() = "Flash ${PathUtil.getFileName(path)}"
 
-          checkCanceled()
+    override fun writeExternal(element: Element) {
+        super.writeExternal(element)
+        element.setAttribute("path", path)
+        element.setAttribute("run-repl-on-success", if (runReplOnSuccess) "yes" else "no")
+        element.setAttribute("reset-on-success", if (resetOnSuccess) "yes" else "no")
+    }
+
+    override fun readExternal(element: Element) {
+        super.readExternal(element)
+        configurationModule.readExternal(element)
+        element.getAttributeValue("path")?.let {
+            path = it
+        }
+        element.getAttributeValue("run-repl-on-success")?.let {
+            runReplOnSuccess = it == "yes"
+        }
+        element.getAttributeValue("reset-on-success")?.let {
+            resetOnSuccess = it == "yes"
+        }
+    }
+
+    val module: Module?
+        get() {
+            if (path.isEmpty()) {
+                val projectDir = project.guessProjectDir()
+                if (projectDir != null) return ModuleUtil.findModuleForFile(projectDir, project)
+            }
+            val file = StandardFileSystems.local().findFileByPath(path) ?: return null
+            return ModuleUtil.findModuleForFile(file, project)
         }
 
-        reportSequentialProgress(filesToUpload.size) { reporter ->
-          val fileSystem = fileSystemWidget.getDeviceFileSystem()
+    companion object {
+        private fun VirtualFile.leadingDot() = this.name.startsWith(".")
 
-          filesToUpload.forEach { file ->
-            val path = when {
-              sourceFolders.find { VfsUtil.isAncestor(it, file, false) }?.let { sourceRoot ->
-                VfsUtil.getRelativePath(file, sourceRoot) ?: file.name
-              } != null -> VfsUtil.getRelativePath(file, sourceFolders.find { VfsUtil.isAncestor(it, file, false) }!!) ?: file.name
+        private fun collectProjectUploadables(project: Project): Set<VirtualFile> {
+            return project.modules.flatMap { module ->
+                val moduleRoots = module.rootManager
+                    .contentEntries
+                    .flatMap { it.sourceFolders.asSequence() }
+                    .mapNotNull { if (!it.isTestSource) it.file else null }
+                    .filter { !it.leadingDot() }
+                    .toMutableList()
 
-              testFolders.find { VfsUtil.isAncestor(it, file, false) }?.let { sourceRoot ->
-                VfsUtil.getRelativePath(file, sourceRoot) ?: file.name
-              } != null -> VfsUtil.getRelativePath(file, testFolders.find { VfsUtil.isAncestor(it, file, false) }!!) ?: file.name
-
-              else -> project.guessProjectDir()?.let { VfsUtil.getRelativePath(file, it) } ?: file.name
-            }
-            reporter.itemStep(path)
-
-            val deviceFile = fileSystem.files[path]
-
-            if (deviceFile != null &&
-              deviceFile.fullPath == path &&
-              deviceFile.size == file.length &&
-              fileSystemWidget.doesCRCMatch(deviceFile.fullPath, file)
-            ) {
-              return@forEach
-            }
-
-            fileSystemWidget.upload(path, file.contentsToByteArray())
-          }
+                if (moduleRoots.isEmpty()) {
+                    module.rootManager.contentRoots.filterTo(moduleRoots) { it.isDirectory && !it.leadingDot() }
+                }
+                moduleRoots
+            }.toSet()
         }
-        fileSystemWidget.refresh()
-      }
-      return true
+
+        private fun collectExcluded(project: Project): Set<VirtualFile> {
+            val ideaDir = project.stateStore.directoryStorePath?.let { VfsUtil.findFile(it, false) }
+            val excludes = if (ideaDir == null) mutableSetOf<VirtualFile>() else mutableSetOf(ideaDir)
+            project.modules.forEach { module ->
+                PythonSdkUtil.findPythonSdk(module)?.homeDirectory?.apply { excludes.add(this) }
+                module.rootManager.contentEntries.forEach { entry ->
+                    excludes.addAll(entry.excludeFolderFiles)
+                }
+            }
+            return excludes
+        }
+
+        private fun collectSourceRoots(project: Project): Set<VirtualFile> {
+            return project.modules.flatMap { module ->
+                module.rootManager.contentEntries
+                    .flatMap { entry -> entry.sourceFolders.toList() }
+                    .filter { sourceFolder ->
+                        !sourceFolder.isTestSource && sourceFolder.file?.let { !it.leadingDot() } ?: false
+                    }
+                    .mapNotNull { it.file }
+            }.toSet()
+        }
+
+        private fun collectTestRoots(project: Project): Set<VirtualFile> {
+            return project.modules.flatMap { module ->
+                module.rootManager.contentEntries
+                    .flatMap { entry -> entry.sourceFolders.toList() }
+                    .filter { sourceFolder -> sourceFolder.isTestSource }
+                    .mapNotNull { it.file }
+            }.toSet()
+        }
+
+        fun uploadProject(project: Project): Boolean {
+            FileDocumentManager.getInstance().saveAllDocuments()
+            val filesToUpload = collectProjectUploadables(project)
+            return performUpload(project, filesToUpload, true)
+        }
+
+        fun uploadFileOrFolder(project: Project, toUpload: VirtualFile): Boolean {
+            FileDocumentManager.getInstance().saveAllDocuments()
+            return performUpload(project, setOf(toUpload), false)
+        }
+
+        fun uploadItems(project: Project, toUpload: Set<VirtualFile>): Boolean {
+            FileDocumentManager.getInstance().saveAllDocuments()
+            return performUpload(project, toUpload, false)
+        }
+
+        private fun performUpload(project: Project, toUpload: Set<VirtualFile>, initialIsProjectUpload: Boolean): Boolean {
+            var isProjectUpload = initialIsProjectUpload
+            var filesToUpload = toUpload.toMutableList()
+            val excludedFolders = collectExcluded(project)
+            val sourceFolders = collectSourceRoots(project)
+            val testFolders = collectTestRoots(project)
+            val projectDir = project.guessProjectDir()
+
+            performReplAction(project, true, "Upload files") { fileSystemWidget ->
+                var i = 0
+                while (i < filesToUpload.size) {
+                    val file = filesToUpload[i]
+
+                    val shouldSkip = !file.isValid ||
+                            (file.leadingDot() && file != projectDir) ||
+                            FileTypeRegistry.getInstance().isFileIgnored(file) ||
+                            excludedFolders.any { VfsUtil.isAncestor(it, file, true) } ||
+                            (isProjectUpload && testFolders.any { VfsUtil.isAncestor(it, file, true) }) ||
+                            (isProjectUpload && sourceFolders.isNotEmpty() &&
+                                    !sourceFolders.any { VfsUtil.isAncestor(it, file, false) })
+
+                    when {
+                        shouldSkip -> {
+                            filesToUpload.removeAt(i)
+                        }
+
+                        file == projectDir -> {
+                            i = 0
+                            filesToUpload.clear()
+                            filesToUpload = collectProjectUploadables(project).toMutableList()
+                            isProjectUpload = true
+                        }
+
+                        file.isDirectory -> {
+                            filesToUpload.addAll(file.children)
+                            filesToUpload.removeAt(i)
+                        }
+
+                        else -> i++
+                    }
+
+                    checkCanceled()
+                }
+
+                val uniqueFilesToUpload = filesToUpload.distinct()
+
+                reportSequentialProgress(uniqueFilesToUpload.size) { reporter ->
+                    val fileSystem = fileSystemWidget.getDeviceFileSystem()
+
+                    uniqueFilesToUpload.forEach { file ->
+                        val path = when {
+                            sourceFolders.find { VfsUtil.isAncestor(it, file, false) }?.let { sourceRoot ->
+                                VfsUtil.getRelativePath(file, sourceRoot) ?: file.name
+                            } != null -> VfsUtil.getRelativePath(file, sourceFolders.find { VfsUtil.isAncestor(it, file, false) }!!) ?: file.name
+
+                            testFolders.find { VfsUtil.isAncestor(it, file, false) }?.let { sourceRoot ->
+                                VfsUtil.getRelativePath(file, sourceRoot) ?: file.name
+                            } != null -> VfsUtil.getRelativePath(file, testFolders.find { VfsUtil.isAncestor(it, file, false) }!!) ?: file.name
+
+                            else -> projectDir?.let { VfsUtil.getRelativePath(file, it) } ?: file.name
+                        }
+                        reporter.itemStep(path)
+
+                        val deviceFile = fileSystem.files[path]
+
+                        if (deviceFile != null &&
+                            deviceFile.fullPath == path &&
+                            deviceFile.size == file.length &&
+                            fileSystemWidget.doesCRCMatch(deviceFile.fullPath, file)
+                        ) {
+                            return@forEach
+                        }
+
+                        fileSystemWidget.upload(path, file.contentsToByteArray())
+                    }
+                }
+                fileSystemWidget.refresh()
+            }
+            return true
+        }
     }
-  }
 }

--- a/src/main/kotlin/com/jetbrains/micropython/run/MicroPythonRunConfiguration.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/run/MicroPythonRunConfiguration.kt
@@ -151,17 +151,11 @@ class MicroPythonRunConfiguration(project: Project, factory: ConfigurationFactor
 
         private fun collectProjectUploadables(project: Project): Set<VirtualFile> {
             return project.modules.flatMap { module ->
-                val moduleRoots = module.rootManager
-                    .contentEntries
-                    .flatMap { it.sourceFolders.asSequence() }
-                    .mapNotNull { if (!it.isTestSource) it.file else null }
+                module.rootManager.contentEntries
+                    .mapNotNull { it.file }
+                    .flatMap { it.children.toList() }
                     .filter { !it.leadingDot() }
                     .toMutableList()
-
-                if (moduleRoots.isEmpty()) {
-                    module.rootManager.contentRoots.filterTo(moduleRoots) { it.isDirectory && !it.leadingDot() }
-                }
-                moduleRoots
             }.toSet()
         }
 

--- a/src/main/kotlin/com/jetbrains/micropython/run/MicroPythonRunConfiguration.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/run/MicroPythonRunConfiguration.kt
@@ -260,8 +260,6 @@ class MicroPythonRunConfiguration(project: Project, factory: ConfigurationFactor
                 val uniqueFilesToUpload = filesToUpload.distinct()
 
                 reportSequentialProgress(uniqueFilesToUpload.size) { reporter ->
-                    val fileSystem = fileSystemWidget.getDeviceFileSystem()
-
                     uniqueFilesToUpload.forEach { file ->
                         val path = when {
                             sourceFolders.find { VfsUtil.isAncestor(it, file, false) }?.let { sourceRoot ->
@@ -275,16 +273,6 @@ class MicroPythonRunConfiguration(project: Project, factory: ConfigurationFactor
                             else -> projectDir?.let { VfsUtil.getRelativePath(file, it) } ?: file.name
                         }
                         reporter.itemStep(path)
-
-                        val deviceFile = fileSystem.files[path]
-
-                        if (deviceFile != null &&
-                            deviceFile.fullPath == path &&
-                            deviceFile.size == file.length &&
-                            fileSystemWidget.doesCRCMatch(deviceFile.fullPath, file)
-                        ) {
-                            return@forEach
-                        }
 
                         fileSystemWidget.upload(path, file.contentsToByteArray())
                     }


### PR DESCRIPTION
I've made plenty of changes to this plugin and most of them are somehow intertwined, which makes it very difficult to separate them into individual pull-requests in a sensible way. Thus I've decided to close the other pull requests and unite all the changes I've made into this multi-purpose one.

Biggest new thing is that I've had a shot at implementing a CRC check when uploading files, to avoid uploading files that already exist on the device file system. The logic first compares the would-be path of a file being uploaded with files already on the file system, then it compares the file sizes and finally it compares the CRC checksums to determine if the files really match. 

I've tested this functionality on my ESP32 boards, where it seems to work without a problem. However, I'm uncertain about how well devices like the ESP8266 would handle this functionality, so I have a question for you - should there be a toggle in the settings? To disable this check if someone is working with a very resource-constrained controller?

I took the existing file upload algorithm code and threw most of it out of the window, the checks were very repetitive and it was very difficult to see what was happening in different parts of the giga-conditional the performUpload function was. 

I've tested this new code with the two test projects you included in the repository, with my own large project and then I did some manual checks to see if everything behaves as expected. I know you have mentioned that you're working on some rigorous tests for this logic, so most likely they'll have the ultimate word on whether or not this new algorithm works, but from the tests I ran, it seems alright.

This commit includes my changes to the project file view context menu actions. `Execute in REPL...` should now only be clickable for single non-directory file selections. `Upload Item(s)...` works in the way I have outlined in a previous commit, meaning: 

1. All file selections will be processed, no matter how many files or folders they contain.
2. If a folder is selected, all of its contents will be added to the `filestToUpload` list.
3. The list of files is converted to a new one with `distinct()` right before uploading the files to avoid duplicates.
4. If the project root itself is present in the selection, the upload algorithm will catch it, and act accordingly to properly upload the whole project with all the rules this is meant to have.
5. Cosmetically, the action description changes based on the selected items.

The functionality for uploading files directly to the root without positioning them accordingly in the project is not in these commits, but if you'd want this functionality to be implemented, I'll gladly add it in the form of a separate well labeled action.

I've also added file tree view sorting. It follows the usual alphabetical folders first sorting approach and it should work even for deep recursion into sub folders.

The plugin contains my fix for the bug where the plugin disconnects from the board if an upload/deletetion operation is cancelled. Which is a simple `(e: CancellationException)` catch and rethrow `throw e`. Then in the FileSystemWidget  `upload` and `deleteCurrent` methods I catch this exception yet again and call the following code to refresh the file system view:
                
```
withContext(NonCancellable) {
    refresh()
}
```

Given that if the `refresh()` method was run without the `NonCancellable` context it would get cancelled alongside its calling `upload` or `deleteCurrent` method, I've opted to stick with using `NonCancellable`. Now that I no longer call it on the EDT thread like I did before, I believe that the freezing concerns you expressed no longer apply, but please do correct me if I'm mistaken.

Alongside this fix I've added my fix for frequent `ENOENT` errors I experienced when deleting many larger files from the device File System. I haven't looked through the logic to see what exactly caused this, but I've modified the handling of the `(e: IOException)` in `deleteCurrent`. The logic only throws the exception if it doesn't contain `ENOENT`.