### PR TITLE
Cancellation temporary fix

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/nova/FileSystemWidget.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/FileSystemWidget.kt
@@ -37,10 +37,7 @@ import com.jediterm.terminal.TerminalColor
 import com.jediterm.terminal.TtyConnector
 import com.jediterm.terminal.ui.JediTermWidget
 import com.jetbrains.micropython.settings.DEFAULT_WEBREPL_URL
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import org.jetbrains.annotations.NonNls
 import java.awt.BorderLayout
 import java.io.IOException
@@ -232,8 +229,19 @@ class FileSystemWidget(val project: Project, newDisposable: Disposable) :
                     }
                 }
                 .toCollection(commands)
-            blindExecute(LONG_TIMEOUT, *commands.toTypedArray())
-                .extractResponse()
+            try {
+                blindExecute(LONG_TIMEOUT, *commands.toTypedArray())
+                    .extractResponse()
+            } catch (e: IOException) {
+                if (e.message?.contains("ENOENT") != true) {
+                    throw e
+                }
+            } catch (e: CancellationException) {
+                withContext(NonCancellable) {
+                    refresh()
+                }
+                throw e
+            }
         }
     }
 
@@ -246,8 +254,16 @@ class FileSystemWidget(val project: Project, newDisposable: Disposable) :
     }
 
     @Throws(IOException::class)
-    suspend fun upload(relativeName: @NonNls String, contentsToByteArray: ByteArray) =
-        comm.upload(relativeName, contentsToByteArray)
+    suspend fun upload(relativeName: @NonNls String, contentsToByteArray: ByteArray) {
+        try {
+            comm.upload(relativeName, contentsToByteArray)
+        } catch (e: CancellationException) {
+            withContext(NonCancellable) {
+                refresh()
+            }
+            throw e
+        }
+    }
 
     @Throws(IOException::class)
     suspend fun download(deviceFileName: @NonNls String): ByteArray =

--- a/src/main/kotlin/com/jetbrains/micropython/nova/MpyComm.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/MpyComm.kt
@@ -218,7 +218,10 @@ except OSError as e:
                     }
                 }
                 return result
-            } catch (e: Throwable) {
+            } catch (e: CancellationException) {
+                throw e
+            }
+            catch (e: Throwable) {
                 state = State.DISCONNECTED
                 client?.close()
                 client = null


### PR DESCRIPTION
This pull request contains several fixes for upload related bugs:

1. Temporary solution for refreshing the File System view after cancelling an upload/deletion operation.
2. Catch and throw CancellationException in doBlindExecute method to ensure the device won't disconnect after cancelling an operation.
3. Catch and ignore ENOENT errors when deleting files as they cause unnecessary errors.