### PR TITLE
New upload algorithm and modified actions

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
@@ -270,7 +270,7 @@ open class UploadFile() : DumbAwareAction("Upload Item(s) to MicroPython Device"
         val files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)
         if (project != null && files != null) {
             var directoryCount = 0
-            var normalFileCount = 0
+            var fileCount = 0
 
             for (file in files.iterator()) {
                 if (file == null || !file.isInLocalFileSystem || ModuleUtil.findModuleForFile(
@@ -284,15 +284,15 @@ open class UploadFile() : DumbAwareAction("Upload Item(s) to MicroPython Device"
                 if (file.isDirectory) {
                     directoryCount++
                 } else {
-                    normalFileCount++
+                    fileCount++
                 }
             }
 
-            if (normalFileCount >= 1 && directoryCount >= 1) {
+            if (fileCount >= 1 && directoryCount >= 1) {
                 e.presentation.text = "Upload Items to MicroPython Device"
-            } else if (normalFileCount == 1) {
+            } else if (fileCount == 1) {
                 e.presentation.text = "Upload File to MicroPython Device"
-            } else if (normalFileCount > 1) {
+            } else if (fileCount > 1) {
                 e.presentation.text = "Upload Files to MicroPython Device"
             } else if (directoryCount == 1) {
                 e.presentation.text = "Upload Directory to MicroPython Device"

--- a/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
@@ -185,7 +185,7 @@ class InstantRun : DumbAwareAction() {
                 !file.isDirectory &&
                 files?.size == 1 &&
                 (file.fileType == PythonFileType.INSTANCE ||
-                        file.extension == ".mpy")
+                        file.extension == "mpy")
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/nova/actions.kt
@@ -170,15 +170,18 @@ class InstantRun : DumbAwareAction() {
     override fun getActionUpdateThread(): ActionUpdateThread = BGT
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabled = e.getData(CommonDataKeys.VIRTUAL_FILE) != null
-
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        val files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)
+        e.presentation.isEnabled = file != null &&
+                !file.isDirectory &&
+                files?.size == 1
     }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         FileDocumentManager.getInstance().saveAllDocuments()
         val code = e.getData(CommonDataKeys.VIRTUAL_FILE)?.readText() ?: return
-        performReplAction(project,true,"Run code") {
+        performReplAction(project, true, "Run code") {
             it.instantRun(code, false)
         }
     }
@@ -259,28 +262,55 @@ class OpenMpyFile : ReplAction("Open file", true) {
     }
 }
 
-open class UploadFile() : DumbAwareAction("Upload File(s) to MicroPython Device") {
+open class UploadFile() : DumbAwareAction("Upload Item(s) to MicroPython Device") {
     override fun getActionUpdateThread(): ActionUpdateThread = BGT
 
     override fun update(e: AnActionEvent) {
         val project = e.project
-        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
-        if (project != null
-            && file?.isInLocalFileSystem == true
-            && ModuleUtil.findModuleForFile(file, project)?.microPythonFacet != null
-        ) {
-            e.presentation.text =
-                if (file.isDirectory) "Upload Directory to MicroPython Device" else "Upload File to MicroPython Device"
+        val files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)
+        if (project != null && files != null) {
+            var directoryCount = 0
+            var normalFileCount = 0
+
+            for (file in files.iterator()) {
+                if (file == null || !file.isInLocalFileSystem || ModuleUtil.findModuleForFile(
+                        file,
+                        project
+                    )?.microPythonFacet == null
+                ) {
+                    return
+                }
+
+                if (file.isDirectory) {
+                    directoryCount++
+                } else {
+                    normalFileCount++
+                }
+            }
+
+            if (normalFileCount >= 1 && directoryCount >= 1) {
+                e.presentation.text = "Upload Items to MicroPython Device"
+            } else if (normalFileCount == 1) {
+                e.presentation.text = "Upload File to MicroPython Device"
+            } else if (normalFileCount > 1) {
+                e.presentation.text = "Upload Files to MicroPython Device"
+            } else if (directoryCount == 1) {
+                e.presentation.text = "Upload Directory to MicroPython Device"
+            } else if (directoryCount > 1) {
+                e.presentation.text = "Upload Directories to MicroPython Device"
+            } else {
+                e.presentation.text = "Upload Item(s) to MicroPython Device"
+            }
         } else {
             e.presentation.isEnabledAndVisible = false
         }
     }
 
     override fun actionPerformed(e: AnActionEvent) {
-            FileDocumentManager.getInstance().saveAllDocuments()
-        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
-        if (file != null) {
-            MicroPythonRunConfiguration.uploadFileOrFolder(e.project ?: return, file)
+        FileDocumentManager.getInstance().saveAllDocuments()
+        val files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)
+        if (files != null) {
+            MicroPythonRunConfiguration.uploadItems(e.project ?: return, files.toSet())
         }
     }
 }
@@ -292,9 +322,9 @@ class OpenSettingsAction : DumbAwareAction("Settings") {
     }
 }
 
-class InterruptAction: ReplAction("Interrupt", true) {
+class InterruptAction : ReplAction("Interrupt", true) {
     override fun getActionUpdateThread(): ActionUpdateThread = BGT
-    override fun update(e: AnActionEvent)  = enableIfConnected(e)
+    override fun update(e: AnActionEvent) = enableIfConnected(e)
     override val actionDescription: @NlsContexts.DialogMessage String = "Interrupt..."
 
     override suspend fun performAction(fileSystemWidget: FileSystemWidget) {
@@ -302,9 +332,9 @@ class InterruptAction: ReplAction("Interrupt", true) {
     }
 }
 
-class SoftResetAction: ReplAction("Reset", true) {
+class SoftResetAction : ReplAction("Reset", true) {
     override fun getActionUpdateThread(): ActionUpdateThread = BGT
-    override fun update(e: AnActionEvent)  = enableIfConnected(e)
+    override fun update(e: AnActionEvent) = enableIfConnected(e)
     override val actionDescription: @NlsContexts.DialogMessage String = "Reset..."
 
     override suspend fun performAction(fileSystemWidget: FileSystemWidget) {
@@ -326,7 +356,7 @@ class CreateDeviceFolderAction : ReplAction("New Folder", true) {
         }
     }
 
-    override val actionDescription: @NlsContexts.DialogMessage String = "Creating new folder..."
+    override val actionDescription: @NlsContexts.DialogMessage String = "Creating New Folder..."
 
     override suspend fun performAction(fileSystemWidget: FileSystemWidget) {
 

--- a/src/main/kotlin/com/jetbrains/micropython/run/MicroPythonRunConfiguration.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/run/MicroPythonRunConfiguration.kt
@@ -25,7 +25,6 @@ import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.facet.ui.ValidationResult
-import com.intellij.openapi.application.EDT
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileTypes.FileTypeRegistry
 import com.intellij.openapi.module.Module
@@ -49,184 +48,237 @@ import com.jetbrains.micropython.nova.performReplAction
 import com.jetbrains.micropython.settings.MicroPythonProjectConfigurable
 import com.jetbrains.micropython.settings.microPythonFacet
 import com.jetbrains.python.sdk.PythonSdkUtil
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.jdom.Element
-import java.nio.file.Path
-
 
 /**
- * @author Mikhail Golubev
+ * @author Mikhail Golubev, Lukas Kremla
  */
-
 class MicroPythonRunConfiguration(project: Project, factory: ConfigurationFactory) : AbstractRunConfiguration(project, factory), RunConfigurationWithSuppressedDefaultDebugAction {
+    var path: String = ""
+    var runReplOnSuccess: Boolean = false
+    var resetOnSuccess: Boolean = true
 
-  var path: String = ""
-  var runReplOnSuccess: Boolean = false
-  var resetOnSuccess: Boolean = true
+    override fun getValidModules() =
+        allModules.filter { it.microPythonFacet != null }.toMutableList()
 
-  override fun getValidModules() =
-          allModules.filter { it.microPythonFacet != null }.toMutableList()
+    override fun getConfigurationEditor() = MicroPythonRunConfigurationEditor(this)
 
-  override fun getConfigurationEditor() = MicroPythonRunConfigurationEditor(this)
-
-
-  override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? {
-    val success: Boolean
-    if (path.isBlank()) {
-      success = uploadProject(project)
-    } else {
-      val toUpload = VfsUtil.findFile(Path.of(project.basePath ?: return null), true) ?: return null
-      success = uploadFileOrFolder(project, toUpload)
-    }
-    if (success) {
-      val fileSystemWidget = fileSystemWidget(project)
-      if(resetOnSuccess)fileSystemWidget?.reset()
-      if(runReplOnSuccess) fileSystemWidget?.activateRepl()
-      return EmptyRunProfileState.INSTANCE
-    } else {
-      return null
-    }
-  }
-
-
-  override fun checkConfiguration() {
-    super.checkConfiguration()
-    val m = module ?: throw RuntimeConfigurationError("Module for path was not found")
-    val showSettings = Runnable {
-      when {
-        PlatformUtils.isPyCharm() ->
-          ShowSettingsUtil.getInstance().showSettingsDialog(project, MicroPythonProjectConfigurable::class.java)
-        PlatformUtils.isIntelliJ() ->
-          ProjectSettingsService.getInstance(project).openModuleSettings(module)
-        else ->
-          ShowSettingsUtil.getInstance().showSettingsDialog(project)
-      }
-    }
-    val facet = m.microPythonFacet ?: throw RuntimeConfigurationError(
-            "MicroPython support is not enabled for selected module in IDE settings",
-            showSettings
-    )
-    val validationResult = facet.checkValid()
-    if (validationResult != ValidationResult.OK) {
-      val runQuickFix = Runnable {
-        validationResult.quickFix.run(null)
-      }
-      throw RuntimeConfigurationError(validationResult.errorMessage, runQuickFix)
-    }
-    facet.pythonPath ?: throw RuntimeConfigurationError("Python interpreter was not found")
-  }
-
-  override fun suggestedName() = "Flash ${PathUtil.getFileName(path)}"
-
-  override fun writeExternal(element: Element) {
-    super.writeExternal(element)
-    element.setAttribute("path", path)
-    element.setAttribute("run-repl-on-success", if (runReplOnSuccess) "yes" else "no")
-    element.setAttribute("reset-on-success", if (resetOnSuccess) "yes" else "no")
-  }
-
-  override fun readExternal(element: Element) {
-    super.readExternal(element)
-    configurationModule.readExternal(element)
-    element.getAttributeValue("path")?.let {
-      path = it
-    }
-    element.getAttributeValue("run-repl-on-success")?.let {
-      runReplOnSuccess = it == "yes"
-    }
-    element.getAttributeValue("reset-on-success")?.let {
-      resetOnSuccess = it == "yes"
-    }
-  }
-
-  val module: Module?
-    get() {
-      if (path.isEmpty()) {
+    override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? {
+        val success: Boolean
         val projectDir = project.guessProjectDir()
-        if (projectDir != null) return ModuleUtil.findModuleForFile(projectDir, project)
-      }
-      val file = StandardFileSystems.local().findFileByPath(path) ?: return null
-      return ModuleUtil.findModuleForFile(file, project)
-    }
+        val projectPath = projectDir?.path
 
-  companion object {
-
-    private fun VirtualFile.leadingDot() = this.name.startsWith(".")
-
-    fun uploadFileOrFolder(project: Project, toUpload: VirtualFile): Boolean {
-      FileDocumentManager.getInstance().saveAllDocuments()
-      performUpload(project,listOf(toUpload.name to toUpload))
-      return false
-    }
-
-    private fun collectUploadables(project: Project): Set<VirtualFile> {
-      return project.modules.flatMap { module ->
-        val moduleRoots = module.rootManager
-          .contentEntries
-          .flatMap { it.sourceFolders.asSequence() }
-          .mapNotNull { if (!it.isTestSource) it.file else null }
-          .filter { !it.leadingDot() }
-          .toMutableList()
-
-        if (moduleRoots.isEmpty()) {
-          module.rootManager.contentRoots.filterTo(moduleRoots) { it.isDirectory && !it.leadingDot() }
+        if (path.isBlank() || (projectPath != null && path == projectPath)) {
+            success = uploadProject(project)
+        } else {
+            val toUpload = StandardFileSystems.local().findFileByPath(path) ?: return null
+            success = uploadFileOrFolder(project, toUpload)
         }
-        moduleRoots
-      }.toSet()
+        if (success) {
+            val fileSystemWidget = fileSystemWidget(project)
+            if (resetOnSuccess) fileSystemWidget?.reset()
+            if (runReplOnSuccess) fileSystemWidget?.activateRepl()
+            return EmptyRunProfileState.INSTANCE
+        } else {
+            return null
+        }
     }
 
-    private fun collectExcluded(project: Project): Set<VirtualFile> {
-      val ideaDir = project.stateStore.directoryStorePath?.let { VfsUtil.findFile(it, false) }
-      val excludes = if (ideaDir == null) mutableSetOf<VirtualFile>() else mutableSetOf(ideaDir)
-      project.modules.forEach { module ->
-        PythonSdkUtil.findPythonSdk(module)?.homeDirectory?.apply { excludes.add(this) }
-        module.rootManager.contentEntries.forEach { entry ->
-          excludes.addAll(entry.excludeFolderFiles)
+    override fun checkConfiguration() {
+        super.checkConfiguration()
+        val m = module ?: throw RuntimeConfigurationError("Module for path was not found")
+        val showSettings = Runnable {
+            when {
+                PlatformUtils.isPyCharm() ->
+                    ShowSettingsUtil.getInstance().showSettingsDialog(project, MicroPythonProjectConfigurable::class.java)
+
+                PlatformUtils.isIntelliJ() ->
+                    ProjectSettingsService.getInstance(project).openModuleSettings(module)
+
+                else ->
+                    ShowSettingsUtil.getInstance().showSettingsDialog(project)
+            }
         }
-      }
-      return excludes
+        val facet = m.microPythonFacet ?: throw RuntimeConfigurationError(
+            "MicroPython support was not enabled for selected module in IDE settings",
+            showSettings
+        )
+        val validationResult = facet.checkValid()
+        if (validationResult != ValidationResult.OK) {
+            val runQuickFix = Runnable {
+                validationResult.quickFix.run(null)
+            }
+            throw RuntimeConfigurationError(validationResult.errorMessage, runQuickFix)
+        }
+        facet.pythonPath ?: throw RuntimeConfigurationError("Python interpreter is not found")
     }
 
-    fun uploadProject(project: Project): Boolean {
-      val filesToUpload = collectUploadables(project).map { file -> "" to file }.toMutableList()
-      return performUpload(project, filesToUpload)
+    override fun suggestedName() = "Flash ${PathUtil.getFileName(path)}"
+
+    override fun writeExternal(element: Element) {
+        super.writeExternal(element)
+        element.setAttribute("path", path)
+        element.setAttribute("run-repl-on-success", if (runReplOnSuccess) "yes" else "no")
+        element.setAttribute("reset-on-success", if (resetOnSuccess) "yes" else "no")
     }
 
-    private fun performUpload(project: Project, filesToUpload: List<Pair<String, VirtualFile>>): Boolean {
-      val flatListToUpload = filesToUpload.toMutableList()
-      val ignorableFolders = collectExcluded(project)
-      performReplAction(project, true, "Upload files") { fileSystemWidget ->
-        withContext(Dispatchers.EDT) {
-          FileDocumentManager.getInstance().saveAllDocuments()
+    override fun readExternal(element: Element) {
+        super.readExternal(element)
+        configurationModule.readExternal(element)
+        element.getAttributeValue("path")?.let {
+            path = it
         }
-        val fileTypeRegistry = FileTypeRegistry.getInstance()
-        var index = 0
-        while (index < flatListToUpload.size) {
-          val file = flatListToUpload[index].second
-          if (!file.isValid || file.leadingDot() || fileTypeRegistry.isFileIgnored(file)) {
-            flatListToUpload.removeAt(index)
-          } else if (ignorableFolders.any { VfsUtil.isAncestor(it, file, true) }) {
-            flatListToUpload.removeAt(index)
-          } else if (file.isDirectory) {
-            file.children.forEach {  flatListToUpload.add("${flatListToUpload[index].first}/${it.name}" to it) }
-            flatListToUpload.removeAt(index)
-          } else {
-            index++
-          }
-          checkCanceled()
+        element.getAttributeValue("run-repl-on-success")?.let {
+            runReplOnSuccess = it == "yes"
         }
-        //todo low priority create empty folders
-        reportSequentialProgress(flatListToUpload.size) { reporter ->
-          flatListToUpload.forEach { (path, file) ->
-            reporter.itemStep(path)
-            fileSystemWidget.upload(path, file.contentsToByteArray())
-          }
+        element.getAttributeValue("reset-on-success")?.let {
+            resetOnSuccess = it == "yes"
         }
-        fileSystemWidget.refresh()
-      }
-      return true
     }
 
-  }
+    val module: Module?
+        get() {
+            if (path.isEmpty()) {
+                val projectDir = project.guessProjectDir()
+                if (projectDir != null) return ModuleUtil.findModuleForFile(projectDir, project)
+            }
+            val file = StandardFileSystems.local().findFileByPath(path) ?: return null
+            return ModuleUtil.findModuleForFile(file, project)
+        }
+
+    companion object {
+        private fun VirtualFile.leadingDot() = this.name.startsWith(".")
+
+        private fun collectProjectUploadables(project: Project): Set<VirtualFile> {
+            return project.modules.flatMap { module ->
+                module.rootManager.contentEntries
+                    .mapNotNull { it.file }
+                    .flatMap { it.children.toList() }
+                    .filter { !it.leadingDot() }
+                    .toMutableList()
+            }.toSet()
+        }
+
+        private fun collectExcluded(project: Project): Set<VirtualFile> {
+            val ideaDir = project.stateStore.directoryStorePath?.let { VfsUtil.findFile(it, false) }
+            val excludes = if (ideaDir == null) mutableSetOf() else mutableSetOf(ideaDir)
+            project.modules.forEach { module ->
+                PythonSdkUtil.findPythonSdk(module)?.homeDirectory?.apply { excludes.add(this) }
+                module.rootManager.contentEntries.forEach { entry ->
+                    excludes.addAll(entry.excludeFolderFiles)
+                }
+            }
+            return excludes
+        }
+
+        private fun collectSourceRoots(project: Project): Set<VirtualFile> {
+            return project.modules.flatMap { module ->
+                module.rootManager.contentEntries
+                    .flatMap { entry -> entry.sourceFolders.toList() }
+                    .filter { sourceFolder ->
+                        !sourceFolder.isTestSource && sourceFolder.file?.let { !it.leadingDot() } ?: false
+                    }
+                    .mapNotNull { it.file }
+            }.toSet()
+        }
+
+        private fun collectTestRoots(project: Project): Set<VirtualFile> {
+            return project.modules.flatMap { module ->
+                module.rootManager.contentEntries
+                    .flatMap { entry -> entry.sourceFolders.toList() }
+                    .filter { sourceFolder -> sourceFolder.isTestSource }
+                    .mapNotNull { it.file }
+            }.toSet()
+        }
+
+        fun uploadProject(project: Project): Boolean {
+            FileDocumentManager.getInstance().saveAllDocuments()
+            val filesToUpload = collectProjectUploadables(project)
+            return performUpload(project, filesToUpload, true)
+        }
+
+        fun uploadFileOrFolder(project: Project, toUpload: VirtualFile): Boolean {
+            FileDocumentManager.getInstance().saveAllDocuments()
+            return performUpload(project, setOf(toUpload), false)
+        }
+
+        fun uploadItems(project: Project, toUpload: Set<VirtualFile>): Boolean {
+            FileDocumentManager.getInstance().saveAllDocuments()
+            return performUpload(project, toUpload, false)
+        }
+
+        private fun performUpload(project: Project, toUpload: Set<VirtualFile>, initialIsProjectUpload: Boolean): Boolean {
+            var isProjectUpload = initialIsProjectUpload
+            var filesToUpload = toUpload.toMutableList()
+            val excludedFolders = collectExcluded(project)
+            val sourceFolders = collectSourceRoots(project)
+            val testFolders = collectTestRoots(project)
+            val projectDir = project.guessProjectDir()
+
+            performReplAction(project, true, "Upload files") { fileSystemWidget ->
+                var i = 0
+                while (i < filesToUpload.size) {
+                    val file = filesToUpload[i]
+
+                    val shouldSkip = !file.isValid ||
+                            (file.leadingDot() && file != projectDir) ||
+                            FileTypeRegistry.getInstance().isFileIgnored(file) ||
+                            excludedFolders.any { VfsUtil.isAncestor(it, file, true) } ||
+                            (isProjectUpload && testFolders.any { VfsUtil.isAncestor(it, file, true) }) ||
+                            (isProjectUpload && sourceFolders.isNotEmpty() &&
+                                    !sourceFolders.any { VfsUtil.isAncestor(it, file, false) })
+
+                    when {
+                        shouldSkip -> {
+                            filesToUpload.removeAt(i)
+                        }
+
+                        file == projectDir -> {
+                            i = 0
+                            filesToUpload.clear()
+                            filesToUpload = collectProjectUploadables(project).toMutableList()
+                            isProjectUpload = true
+                        }
+
+                        file.isDirectory -> {
+                            filesToUpload.addAll(file.children)
+                            filesToUpload.removeAt(i)
+                        }
+
+                        else -> i++
+                    }
+
+                    checkCanceled()
+                }
+
+                val uniqueFilesToUpload = filesToUpload.distinct()
+                val fileToTargetPath = mutableMapOf<VirtualFile, String>()
+
+                uniqueFilesToUpload.forEach { file ->
+                    val path = when {
+                        sourceFolders.find { VfsUtil.isAncestor(it, file, false) }?.let { sourceRoot ->
+                            VfsUtil.getRelativePath(file, sourceRoot) ?: file.name
+                        } != null -> VfsUtil.getRelativePath(file, sourceFolders.find { VfsUtil.isAncestor(it, file, false) }!!) ?: file.name
+
+                        testFolders.find { VfsUtil.isAncestor(it, file, false) }?.let { sourceRoot ->
+                            VfsUtil.getRelativePath(file, sourceRoot) ?: file.name
+                        } != null -> VfsUtil.getRelativePath(file, testFolders.find { VfsUtil.isAncestor(it, file, false) }!!) ?: file.name
+
+                        else -> projectDir?.let { VfsUtil.getRelativePath(file, it) } ?: file.name
+                    }
+
+                    fileToTargetPath[file] = path
+                }
+
+                reportSequentialProgress(fileToTargetPath.size) { reporter ->
+                    fileToTargetPath.forEach { (file, path) ->
+                        reporter.itemStep(path)
+                        fileSystemWidget.upload(path, file.contentsToByteArray())
+                    }
+                }
+                fileSystemWidget.refresh()
+            }
+            return true
+        }
+    }
 }


### PR DESCRIPTION
Added new upload algorithm logic for building target file paths and cleaned up existing methods.

Execute in REPL action is now only clickable for single non-directory file selections.

Upload action now uses the new upload algorithm and its description changes based on the current file/folder selection.